### PR TITLE
Fix access to the root entity

### DIFF
--- a/src/BaselineOfFamixTypeScript/BaselineOfFamixTypeScript.class.st
+++ b/src/BaselineOfFamixTypeScript/BaselineOfFamixTypeScript.class.st
@@ -1,0 +1,29 @@
+Class {
+	#name : #BaselineOfFamixTypeScript,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfFamixTypeScript
+}
+
+{ #category : #baselines }
+BaselineOfFamixTypeScript >> baseline: spec [
+	<baseline>
+	spec
+		for: #common
+		do: [ 
+			self defineDependencies: spec.
+			self definePackages: spec.
+			self defineGroups: spec ]
+]
+
+{ #category : #baselines }
+BaselineOfFamixTypeScript >> defineDependencies: spec [
+]
+
+{ #category : #baselines }
+BaselineOfFamixTypeScript >> defineGroups: spec [
+]
+
+{ #category : #baselines }
+BaselineOfFamixTypeScript >> definePackages: spec [
+	spec package: 'Famix-TypeScript-Generator'
+]

--- a/src/BaselineOfFamixTypeScript/package.st
+++ b/src/BaselineOfFamixTypeScript/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfFamixTypeScript }

--- a/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
+++ b/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
@@ -5,7 +5,8 @@ Class {
 		'class',
 		'method',
 		'type',
-		'containerEntity'
+		'containerEntity',
+		'rootEntity'
 	],
 	#category : #'Famix-TypeScript-Generator'
 }
@@ -25,7 +26,7 @@ FamixTypeScriptGenerator class >> prefix [
 { #category : #definition }
 FamixTypeScriptGenerator >> defineClasses [
 	super defineClasses.
-	
+	rootEntity := builder ensureClassNamed: #Entity.
 	class := builder
 		newClassNamed: #Class
 		comment: 'I represent a TypeScript class or interface'.
@@ -58,6 +59,6 @@ FamixTypeScriptGenerator >> defineProperties [
 
     super defineProperties.
 
-   "(entity property: #name type: #String)
-       comment: 'The name of the entity'."
+   (rootEntity property: #name type: #String)
+       comment: 'The name of the entity'.
 ]


### PR DESCRIPTION
## Fix typescript generator access to the root entity

You cannot use the `#entity` slot defined in FamixBasicInfrastructure.
It was an old default property that created a lot of problems when generating models.
The new way is to access the root entity using

```
FamixBasicInfrastructureGenerator>>#MyGenerator
     rootEntity := builder ensureClassName: #Entity
```

> This workaround is only mandatory when you subclass the FamixBasicInfrastructureGenerator

## Add a baseline

I have added a baseline because it makes project installation easier